### PR TITLE
Update single page CRUD interface.

### DIFF
--- a/src/main/java/com/easyedit/controller/DynamicActiveController.java
+++ b/src/main/java/com/easyedit/controller/DynamicActiveController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.easyedit.entity.Page;
@@ -45,7 +46,7 @@ public class DynamicActiveController {
      */
     // @OneidToken
     @PostMapping(value = "")
-    public ResponseResult CreateDynamicActive(@RequestBody Page pageBody) {
+    public ResponseResult CreateDynamicActive(@RequestBody Page pageBody) throws IOException {
         try {
             final ResponseResult result = pageService.createPage(pageBody);
             response.setStatus(result.getHttpStatusCode());
@@ -58,9 +59,22 @@ public class DynamicActiveController {
 
     // @OneidToken
     @GetMapping(value = "/{id}")
-    public ResponseResult GetDynamicActive(@PathVariable String id) throws IOException {
+    public ResponseResult GetDynamicActiveById(@PathVariable Integer id) throws IOException {
         try {
-            ResponseResult result = pageService.getPage(id);
+            ResponseResult result = pageService.getPage(id, "", "");
+            response.setStatus(result.getHttpStatusCode());
+            return result;
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            return ResponseResult.errorResult(ResponseResult.AppHttpCodeEnum.ERROR);
+        }
+    }
+
+    // @OneidToken
+    @GetMapping(value = "")
+    public ResponseResult GetDynamicActiveByName(@RequestParam("path") String path, @RequestParam("name") String name) throws IOException {
+        try {
+            ResponseResult result = pageService.getPage(-1, path, name);
             response.setStatus(result.getHttpStatusCode());
             return result;
         } catch (Exception e) {
@@ -71,9 +85,22 @@ public class DynamicActiveController {
 
     // @OneidToken
     @PutMapping(value = "/{id}")
-    public ResponseResult UpdateDynamicActive(@PathVariable String id, @RequestBody Page page) {
+    public ResponseResult UpdateDynamicActiveById(@PathVariable Integer id, @RequestBody Page page) throws IOException {
         try {
-            ResponseResult result = pageService.updatePage(id, page);
+            ResponseResult result = pageService.updatePage(id, "", "", page);
+            response.setStatus(result.getHttpStatusCode());
+            return result;
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            return ResponseResult.errorResult(ResponseResult.AppHttpCodeEnum.ERROR);
+        }
+    }
+
+    // @OneidToken
+    @PutMapping(value = "")
+    public ResponseResult UpdateDynamicActiveByName(@RequestParam("path") String path, @RequestParam("name") String name, @RequestBody Page page) throws IOException {
+        try {
+            ResponseResult result = pageService.updatePage(-1, path, name, page);
             response.setStatus(result.getHttpStatusCode());
             return result;
         } catch (Exception e) {
@@ -84,9 +111,22 @@ public class DynamicActiveController {
 
     // @OneidToken
     @DeleteMapping(value = "/{id}")
-    public ResponseResult DeleteDynamicActive(@PathVariable String id) {
+    public ResponseResult DeleteDynamicActiveById(@PathVariable Integer id) throws IOException {
         try {
-            ResponseResult result = pageService.deletePage(id);
+            ResponseResult result = pageService.deletePage(id, "", "");
+            response.setStatus(result.getHttpStatusCode());
+            return result;
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            return ResponseResult.errorResult(ResponseResult.AppHttpCodeEnum.ERROR);
+        }
+    }
+
+    // @OneidToken
+    @DeleteMapping(value = "")
+    public ResponseResult DeleteDynamicActiveByName(@RequestParam("path") String path, @RequestParam("name") String name) throws IOException {
+        try {
+            ResponseResult result = pageService.deletePage(-1, path, name);
             response.setStatus(result.getHttpStatusCode());
             return result;
         } catch (Exception e) {

--- a/src/main/java/com/easyedit/entity/Page.java
+++ b/src/main/java/com/easyedit/entity/Page.java
@@ -23,11 +23,7 @@ public class Page implements Serializable {
 
     private String hash;
 
-    private String folder;
-
     private String name;
-
-    private String fullName;
 
     private String title;
 
@@ -77,28 +73,12 @@ public class Page implements Serializable {
         this.hash = hash;
     }
 
-    public String getFolder() {
-        return folder;
-    }
-
-    public void setFolder(String folder) {
-        this.folder = folder;
-    }
-
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getFullName() {
-        return fullName;
-    }
-
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
     }
 
     public String getTitle() {
@@ -203,9 +183,7 @@ public class Page implements Serializable {
             "id = " + id +
             ", path = " + path +
             ", hash = " + hash +
-            ", folder = " + folder +
             ", name = " + name +
-            ", fullName = " + fullName +
             ", title = " + title +
             ", description = " + description +
             ", isPrivate = " + isPrivate +

--- a/src/main/java/com/easyedit/entity/Pagetree.java
+++ b/src/main/java/com/easyedit/entity/Pagetree.java
@@ -1,9 +1,14 @@
 package com.easyedit.entity;
 
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
 import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.baomidou.mybatisplus.extension.handlers.JacksonTypeHandler;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * <p>
@@ -13,12 +18,17 @@ import java.io.Serializable;
  * @author zhongjun
  * @since 2023-02-28
  */
+@TableName(autoResultMap = true)
 public class Pagetree implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     @TableId(value = "id", type = IdType.AUTO)
     private Integer id;
+
+    private String path;
+
+    private String name;
 
     private Integer depth;
 
@@ -30,8 +40,10 @@ public class Pagetree implements Serializable {
 
     private Integer parent;
 
-    private String ancestors;
+    @TableField(typeHandler = JacksonTypeHandler.class)
+    private List<Integer> ancestors;
 
+    @TableField(updateStrategy = FieldStrategy.IGNORED)
     private Integer pageId;
 
     public Integer getId() {
@@ -40,6 +52,22 @@ public class Pagetree implements Serializable {
 
     public void setId(Integer id) {
         this.id = id;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Integer getDepth() {
@@ -82,11 +110,11 @@ public class Pagetree implements Serializable {
         this.parent = parent;
     }
 
-    public String getAncestors() {
+    public List<Integer> getAncestors() {
         return ancestors;
     }
 
-    public void setAncestors(String ancestors) {
+    public void setAncestors(List<Integer> ancestors) {
         this.ancestors = ancestors;
     }
 
@@ -102,6 +130,8 @@ public class Pagetree implements Serializable {
     public String toString() {
         return "Pagetree{" +
             "id = " + id +
+            ", path = " + path +
+            ", name = " + name +
             ", depth = " + depth +
             ", isEvent = " + isEvent +
             ", isPrivate = " + isPrivate +

--- a/src/main/java/com/easyedit/service/PageService.java
+++ b/src/main/java/com/easyedit/service/PageService.java
@@ -13,8 +13,10 @@ import com.baomidou.mybatisplus.extension.service.IService;
  * @since 2023-03-01
  */
 public interface PageService extends IService<Page> {
+
     ResponseResult createPage(Page page);
-    ResponseResult getPage(String pageId);
-    ResponseResult updatePage(String pageId, Page page);
-    ResponseResult deletePage(String pageId);
+    ResponseResult getPage(Integer pageId, String path, String name);
+    ResponseResult updatePage(Integer pageId, String path, String name, Page page);
+    ResponseResult deletePage(Integer pageId, String path, String name);
+
 }

--- a/src/main/java/com/easyedit/service/PagetreeService.java
+++ b/src/main/java/com/easyedit/service/PagetreeService.java
@@ -2,7 +2,6 @@ package com.easyedit.service;
 
 import com.easyedit.entity.Page;
 import com.easyedit.entity.Pagetree;
-import com.easyedit.util.ResponseResult;
 import com.baomidou.mybatisplus.extension.service.IService;
 
 /**
@@ -15,7 +14,9 @@ import com.baomidou.mybatisplus.extension.service.IService;
  */
 public interface PagetreeService extends IService<Pagetree> {
 
-    void createPagetree(Page page);
-    boolean deletePagetree(String pageId);
-    void updatePagetree(Page page);
+    boolean createPagetree(Page page);
+    boolean updatePagetree(Page page);
+    boolean deletePagetreeById(Integer pageId);
+    boolean deletePagetreeByName(String path, String name);
+
 }

--- a/src/main/java/com/easyedit/service/impl/PagetreeServiceImpl.java
+++ b/src/main/java/com/easyedit/service/impl/PagetreeServiceImpl.java
@@ -2,7 +2,6 @@ package com.easyedit.service.impl;
 
 import com.easyedit.entity.Page;
 import com.easyedit.entity.Pagetree;
-import com.easyedit.mapper.PageMapper;
 import com.easyedit.mapper.PagetreeMapper;
 import com.easyedit.service.PagetreeService;
 
@@ -10,6 +9,8 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,71 +27,167 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PagetreeServiceImpl extends ServiceImpl<PagetreeMapper, Pagetree> implements PagetreeService {
 
     @Autowired
-    private PageMapper pageMapper;
-
-    @Autowired
     private PagetreeMapper pagetreeMapper;
 
     @Override
-    public void createPagetree(Page page) {
-        Pagetree pageTree = new Pagetree();
-        pageTree.setIsPrivate(page.getIsPrivate());
-        pageTree.setPageId(page.getId());
-
-        if (page.getFolder().equals("/")) {
-            pageTree.setDepth(1);
-            String ancestors = "/"; 
-            pageTree.setAncestors(ancestors);
-        } else {
-            Integer parentId = findParent(page.getPath(), page.getFolder());
-            Pagetree parentTree = pagetreeMapper.selectById(parentId);
-            parentTree.setIsFolder(true);
-            pagetreeMapper.updateById(parentTree);
-
-            pageTree.setIsFolder(false);
-            pageTree.setDepth(parentTree.getDepth() + 1);
-            pageTree.setParent(parentId);
-            if (parentTree.getAncestors().equals("/")) {
-                pageTree.setAncestors(parentTree.getAncestors() + parentId);
-            } else {
-                pageTree.setAncestors(parentTree.getAncestors() + "/" + parentId);
-            }
-        }
-
-        pagetreeMapper.insert(pageTree);
-    }
- 
-    private Integer findParent(String path, String folder) {
-        QueryWrapper<Page> wrapper = new QueryWrapper<>();
-        wrapper.eq("path", path).eq("full_name", folder);
-        
-        Page parent = pageMapper.selectOne(wrapper);
-        return parent.getId();
-    }
-
-    @Override
-    public boolean deletePagetree(String pageId) {
-        Pagetree pagetree = pagetreeMapper.selectById(pageId);
-        if (pagetree.getIsFolder() == true) {
-            return false;
-        }
-
-        Integer parentId = pagetree.getParent();
-        pagetreeMapper.deleteById(pageId);
-        
+    public boolean createPagetree(Page page) {
         QueryWrapper<Pagetree> wrapper = new QueryWrapper<>();
-        wrapper.eq("parent", parentId);
-        List<Pagetree> sons= pagetreeMapper.selectList(wrapper);
-        if (sons.size() == 0) {
-            Pagetree parent = new Pagetree();
-            parent.setId(parentId);
-            parent.setIsFolder(false);
-            pagetreeMapper.updateById(parent);
+        String path = page.getPath();
+        String[] allNames = page.getName().split("/");
+        final String GLUECHAR = "/";
+        String varName = "";
+        Integer depth = 1;
+        Integer parent = -1;
+        List<Integer> ancestors = new ArrayList<Integer>();
+        for (String name : allNames) {
+            varName = varName + name;
+            wrapper.eq("path", path).eq("name", varName);
+            Pagetree node = pagetreeMapper.selectOne(wrapper);
+            if (node == null) { // 不存在则新建
+                Pagetree nodeNoPage = new Pagetree();
+                nodeNoPage.setPath(path);
+                nodeNoPage.setName(varName);
+                nodeNoPage.setDepth(depth);
+                nodeNoPage.setIsPrivate(false);
+                if (parent > 0) {
+                    nodeNoPage.setParent(parent);
+                }
+                nodeNoPage.setAncestors(ancestors);
+                if (page.getName().equals(varName)) { // 设置pageId
+                    nodeNoPage.setIsPrivate(page.getIsPrivate());
+                    nodeNoPage.setIsFolder(false);
+                    nodeNoPage.setPageId(page.getId());
+                } else {
+                    nodeNoPage.setIsFolder(true);
+                }
+                
+                int r = pagetreeMapper.insert(nodeNoPage);
+                if (r <= 0) {
+                    return false;
+                }
+                parent = nodeNoPage.getId();
+                ancestors.add(nodeNoPage.getId());
+            } else {
+                if (page.getName().equals(varName)) { // 设置pageId
+                    node.setIsPrivate(page.getIsPrivate());
+                    node.setPageId(page.getId());
+
+                    int r = pagetreeMapper.updateById(node);
+                    if (r <= 0) {
+                        return false;
+                    }
+                } else {
+                    node.setIsFolder(true);
+                    int r = pagetreeMapper.updateById(node);
+                    if (r <= 0) {
+                        return false;
+                    }
+                }
+
+                parent = node.getId();
+                ancestors.add(node.getId());
+            }
+            depth += 1;
+            wrapper.clear();
+            varName = varName + GLUECHAR;
         }
         return true;
     }
 
     @Override
-    public void updatePagetree(Page page) {
+    public boolean updatePagetree(Page page) {
+        // 删除旧节点
+        Integer pageId = page.getId();
+        boolean isDeleted = deletePagetreeById(pageId);
+        if (!isDeleted) {
+            return false;
+        }
+        
+        // 建立新节点
+        boolean isCreated = createPagetree(page);
+        if (!isCreated) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean deletePagetreeById(Integer pageId) {
+        QueryWrapper<Pagetree> wrapper = new QueryWrapper<>();
+        wrapper.eq("page_id", pageId);
+        
+        Pagetree node = pagetreeMapper.selectOne(wrapper);
+        if (node == null) {
+            return false;
+        }
+
+        return deletePagetree(node);
+    }
+
+    @Override
+    public boolean deletePagetreeByName(String path, String name) {
+        QueryWrapper<Pagetree> wrapper = new QueryWrapper<>();
+        wrapper.eq("path", path).eq("name", name);
+        
+        Pagetree node = pagetreeMapper.selectOne(wrapper);
+        if (node == null) {
+            return false;
+        }
+
+        return deletePagetree(node);
+    }
+
+    private boolean deletePagetree(Pagetree node) {
+        if (node.getIsFolder() == true) {
+            node.setPageId(null);
+            node.setIsPrivate(false);
+
+            int r = pagetreeMapper.updateById(node);
+            if (r <= 0) {
+                return false;
+            }
+            return true;
+        } else {
+            List<Integer> ancestors = node.getAncestors();
+            int r = pagetreeMapper.deleteById(node);
+            if (r <= 0) {
+                return false;
+            }
+            if (deleteEmptyNodes(ancestors) == false) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private boolean deleteEmptyNodes(List<Integer> ancestors) {
+        Collections.reverse(ancestors);
+        for (Integer nodeId : ancestors) {
+            QueryWrapper<Pagetree> wrapper = new QueryWrapper<>();
+            wrapper.eq("parent", nodeId);
+        
+            Pagetree son = pagetreeMapper.selectOne(wrapper);
+            Pagetree curNode = pagetreeMapper.selectById(nodeId);
+            if (curNode == null) {
+                return false;
+            }
+            Integer pageId = curNode.getPageId();
+            if (son == null && pageId == null) {
+                int r = pagetreeMapper.deleteById(nodeId);
+                if (r <= 0) {
+                    return false;
+                }
+            } else if (son == null && pageId != null) {
+                curNode.setIsFolder(false);
+                int r = pagetreeMapper.updateById(curNode);
+                if (r <= 0) {
+                    return false;
+                }
+            } else {
+                break;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/easyedit/util/ResponseResult.java
+++ b/src/main/java/com/easyedit/util/ResponseResult.java
@@ -84,6 +84,14 @@ public class ResponseResult implements Serializable {
         return result.error(statusCode, message);
     }
 
+    public static ResponseResult errorResult(Object data) {
+        ResponseResult result = setAppHttpCodeEnum(AppHttpCodeEnum.DATA_ALREADY_EXIST, AppHttpCodeEnum.DATA_ALREADY_EXIST.getMessage());
+        if(data!=null) {
+            result.setData(data);
+        }
+        return result;
+    }
+
     public static ResponseResult okResult(int statusCode, String message) {
         ResponseResult result = new ResponseResult();
         return result.ok(statusCode, null, message);
@@ -152,16 +160,20 @@ public class ResponseResult implements Serializable {
         SUCCESS(200,"successful operation"),
         // 通用失败
         ERROR(5000, "error"),
+        // 请求格式错误
+        BAD_REQUEST(400, "bad request"),
         // 未查询到结果
-        NO_RESULT_FOUND(201, "No result found"),
+        NO_RESULT_FOUND(404, "No result found"),
 
-        NO_DATA_WAS_DELETED(202, "No data was deleted"),
+        NO_DATA_WAS_DELETED(503, "No data was deleted"),
 
-        NO_DATA_WAS_UPDATE(203, "No data was update"),
+        NO_DATA_WAS_UPDATE(503, "No data was update"),
 
-        NO_DATA_WAS_INSERT(204, "No data was insert"),
+        NO_DATA_WAS_INSERT(503, "No data was insert"),
         // 数据插入错误
-        DATA_INSERTION_ERROR(501, "data insertion error");
+        DATA_INSERTION_ERROR(501, "data insertion error"),
+
+        DATA_ALREADY_EXIST(409, "exist data with the same name");
 
         int statusCode;
 


### PR DESCRIPTION
更新简化单个page的接口。
现在仅使用path和name来对page进行区分，name可写成层级形式，后端自动构建树形结构。
查询、更新、删除都可以使用id或者path+name的形式来调用。